### PR TITLE
Add full support for readOnly, max_items, min_items and other schema properties within rendered collections

### DIFF
--- a/examples/complex_disabled_showcase.py
+++ b/examples/complex_disabled_showcase.py
@@ -110,17 +110,15 @@ class DisabledModel(BaseModel):
 
 
 instance = DisabledModel(
-    some_number=999.99,
     short_text="Some INSTANCE text",
     password="$uper_$ecret!",
-    some_alias="Some INSTANCE alias text",
+    long_text="This is some really long text from the INSTANCE",
     positive_integer=20,
+    integer_in_range=28,
     some_date=datetime.date(1999, 9, 9),
     some_time=datetime.time(9, 9, 16),
     some_datetime=datetime.datetime(1999, 9, 9),
-    integer_in_range=28,
     some_boolean=True,
-    long_text="This is some really long text from the INSTANCE",
     single_selection=SelectionValue.FOO,
     disabled_selection=SelectionValue.BAR,
     multi_selection=[SelectionValue.FOO, SelectionValue.BAR],

--- a/examples/complex_disabled_showcase.py
+++ b/examples/complex_disabled_showcase.py
@@ -1,0 +1,118 @@
+import datetime
+from enum import Enum
+from typing import Dict, List, Literal, Optional, Set
+
+import streamlit as st
+from pydantic import BaseModel, Field, SecretStr
+
+import streamlit_pydantic as sp
+from streamlit_pydantic.types import FileContent
+
+
+class SelectionValue(str, Enum):
+    FOO = "foo"
+    BAR = "bar"
+
+
+class OtherData(BaseModel):
+    text: str
+    integer: int
+
+
+class ShowcaseModel(BaseModel):
+    short_text: str = Field(
+        ..., readOnly=True, max_length=60, description="Short text property"
+    )
+    password: SecretStr = Field(
+        ..., readOnly=True, description="Password text property"
+    )
+    long_text: str = Field(
+        ..., format="multi-line", readOnly=True, description="Unlimited text property"
+    )
+    integer_in_range: int = Field(
+        20,
+        ge=10,
+        le=30,
+        multiple_of=2,
+        readOnly=True,
+        description="Number property with a limited range. Optional because of default value.",
+    )
+    positive_integer: int = Field(
+        ...,
+        ge=0,
+        multiple_of=10,
+        readOnly=True,
+        description="Positive integer with step count of 10.",
+    )
+    float_number: float = Field(0.001, readOnly=True)
+    date: Optional[datetime.date] = Field(
+        datetime.date.today(),
+        readOnly=True,
+        description="Date property. Optional because of default value.",
+    )
+    time: Optional[datetime.time] = Field(
+        datetime.datetime.now().time(),
+        readOnly=True,
+        description="Time property. Optional because of default value.",
+    )
+    boolean: bool = Field(
+        False,
+        readOnly=True,
+        description="Boolean property. Optional because of default value.",
+    )
+    read_only_text: str = Field(
+        "Lorem ipsum dolor sit amet",
+        description="This is a ready only text.",
+        readOnly=True,
+    )
+    file_list: Optional[List[FileContent]] = Field(
+        None,
+        readOnly=True,
+        description="A list of files. Optional property.",
+    )
+    single_file: Optional[FileContent] = Field(
+        None,
+        readOnly=True,
+        description="A single file. Optional property.",
+    )
+    single_selection: SelectionValue = Field(
+        ..., readOnly=True, description="Only select a single item from a set."
+    )
+    single_selection_with_literal: Literal["foo", "bar"] = Field(
+        "foo", readOnly=True, description="Only select a single item from a set."
+    )
+    multi_selection: Set[SelectionValue] = Field(
+        ..., readOnly=True, description="Allows multiple items from a set."
+    )
+    multi_selection_with_literal: Set[Literal["foo", "bar"]] = Field(
+        ["foo", "bar"], readOnly=True, description="Allows multiple items from a set."
+    )
+    single_object: OtherData = Field(
+        ...,
+        readOnly=True,
+        description="Another object embedded into this model.",
+    )
+    string_list: List[str] = Field(
+        ..., max_items=20, readOnly=True, description="List of string values"
+    )
+    int_list: List[int] = Field(..., readOnly=True, description="List of int values")
+    string_dict: Dict[str, str] = Field(
+        ..., readOnly=True, description="Dict property with string values"
+    )
+    float_dict: Dict[str, float] = Field(
+        ..., readOnly=True, description="Dict property with float values"
+    )
+    object_list: List[OtherData] = Field(
+        ...,
+        readOnly=True,
+        description="A list of objects embedded into this model.",
+    )
+
+
+session_data = sp.pydantic_input(
+    key="my_input",
+    model=ShowcaseModel,
+)
+
+with st.expander("Current Input State", expanded=False):
+    st.json(session_data)

--- a/examples/complex_disabled_showcase.py
+++ b/examples/complex_disabled_showcase.py
@@ -19,7 +19,7 @@ class OtherData(BaseModel):
     integer: int
 
 
-class ShowcaseModel(BaseModel):
+class DisabledModel(BaseModel):
     short_text: str = Field(
         ..., readOnly=True, max_length=60, description="Short text property"
     )
@@ -62,7 +62,7 @@ class ShowcaseModel(BaseModel):
     )
     read_only_text: str = Field(
         "Lorem ipsum dolor sit amet",
-        description="This is a ready only text.",
+        description="This is a read only text.",
         readOnly=True,
     )
     file_list: Optional[List[FileContent]] = Field(
@@ -109,9 +109,37 @@ class ShowcaseModel(BaseModel):
     )
 
 
+instance = DisabledModel(
+    some_number=999.99,
+    short_text="Some INSTANCE text",
+    password="$uper_$ecret!",
+    some_alias="Some INSTANCE alias text",
+    positive_integer=20,
+    some_date=datetime.date(1999, 9, 9),
+    some_time=datetime.time(9, 9, 16),
+    some_datetime=datetime.datetime(1999, 9, 9),
+    integer_in_range=28,
+    some_boolean=True,
+    long_text="This is some really long text from the INSTANCE",
+    single_selection=SelectionValue.FOO,
+    disabled_selection=SelectionValue.BAR,
+    multi_selection=[SelectionValue.FOO, SelectionValue.BAR],
+    read_only_text="INSTANCE read only text",
+    single_object=OtherData(text="nested data INSTANCE text", integer=66),
+    string_dict={"key 1": "A", "key 2": "B", "key 3": "C"},
+    float_dict={"key A": 9.99, "key B": 66.0, "key C": -55.8},
+    int_list=[9, 99, 999],
+    string_list=["a", "ab", "abc"],
+    object_list=[
+        OtherData(text="object list INSTANCE item 1", integer=6),
+        OtherData(text="object list INSTANCE item 2", integer=99),
+    ],
+)
+
+
 session_data = sp.pydantic_input(
-    key="my_input",
-    model=ShowcaseModel,
+    key="my_disabled_input",
+    model=instance,
 )
 
 with st.expander("Current Input State", expanded=False):

--- a/examples/complex_instance_model.py
+++ b/examples/complex_instance_model.py
@@ -45,6 +45,9 @@ class ExampleModel(BaseModel):
     multi_selection: Set[SelectionValue] = Field(
         ..., description="Allows multiple items from a set."
     )
+    disabled_selection: SelectionValue = Field(
+        ..., readOnly=True, description="A read only field that is shown as disabled"
+    )
     read_only_text: str = Field(
         "Lorem ipsum dolor sit amet",
         description="This is a ready only text.",
@@ -74,6 +77,7 @@ instance = ExampleModel(
     some_boolean=True,
     long_text="This is some really long text from the INSTANCE",
     single_selection=SelectionValue.FOO,
+    disabled_selection=SelectionValue.BAR,
     multi_selection=[SelectionValue.FOO, SelectionValue.BAR],
     read_only_text="INSTANCE read only text",
     nested_object=OtherData(text="nested data INSTANCE text", integer=66),

--- a/examples/complex_instance_model.py
+++ b/examples/complex_instance_model.py
@@ -60,19 +60,26 @@ class ExampleModel(BaseModel):
     int_dict: Dict[str, int] = Field(
         ...,
         description="Dict property with int values",
-        gt=0,
+        gt=-4,
+    )
+    date_dict: Dict[str, datetime.datetime] = Field(
+        ...,
+        description="Dict property with date values",
+    )
+    bool_dict: Dict[str, bool] = Field(
+        ...,
+        description="Dict property with bool values",
     )
     int_list: List[int] = Field(
         ...,
         description="List of int values",
         max_items=4,
         min_items=2,
-        gt=0,
+        gt=2,
     )
     object_list: List[OtherData] = Field(
         ...,
         max_items=5,
-        min_items=1,
         description="A list of objects embedded into this model.",
     )
 
@@ -93,7 +100,9 @@ instance = ExampleModel(
     multi_selection=[SelectionValue.FOO, SelectionValue.BAR],
     read_only_text="INSTANCE read only text",
     nested_object=OtherData(text="nested data INSTANCE text", integer=66),
-    int_dict={"key 1": 3, "key 2": 33, "key 3": 333},
+    int_dict={"key 1": 33, "key 2": 33, "key 3": 333},
+    date_dict={"date_key 1": datetime.datetime(1999, 9, 9)},
+    bool_dict={"bool_key 1": True},
     int_list=[9, 99, 999],
     object_list=[
         OtherData(text="object list INSTANCE item 1", integer=6),

--- a/examples/complex_instance_model.py
+++ b/examples/complex_instance_model.py
@@ -57,10 +57,22 @@ class ExampleModel(BaseModel):
         ...,
         description="Another object embedded into this model.",
     )
-    int_dict: Dict[str, int] = Field(..., description="Dict property with int values")
-    int_list: List[int] = Field(..., description="List of int values")
+    int_dict: Dict[str, int] = Field(
+        ...,
+        description="Dict property with int values",
+        gt=0,
+    )
+    int_list: List[int] = Field(
+        ...,
+        description="List of int values",
+        max_items=4,
+        min_items=2,
+        gt=0,
+    )
     object_list: List[OtherData] = Field(
         ...,
+        max_items=5,
+        min_items=1,
         description="A list of objects embedded into this model.",
     )
 
@@ -89,9 +101,7 @@ instance = ExampleModel(
     ],
 )
 
-# col1, col2 = st.columns(2)
 
-# with col1:
 st.header("Form inputs from model")
 data = sp.pydantic_input(key="my_input_model", model=ExampleModel)
 with st.expander("Current Input State", expanded=False):

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_dir={"": "src"},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     zip_safe=False,
-    install_requires=["streamlit>=1.0.0", "pydantic>=1.9"],
+    install_requires=["streamlit>=1.5.0", "pydantic>=1.9"],
     # deprecated: dependency_links=dependency_links,
     extras_require={
         # extras can be installed via: pip install package[dev]

--- a/src/streamlit_pydantic/ui_renderer.py
+++ b/src/streamlit_pydantic/ui_renderer.py
@@ -336,7 +336,7 @@ class InputUI:
                 with date_col:
                     date_kwargs = {
                         "label": "Date",
-                        "key": streamlit_kwargs.get("key") + "-date-input",
+                        "key": f"{streamlit_kwargs.get('key')}-date-input",
                     }
                     if streamlit_kwargs.get("value"):
                         try:
@@ -350,7 +350,7 @@ class InputUI:
                 with time_col:
                     time_kwargs = {
                         "label": "Time",
-                        "key": streamlit_kwargs.get("key") + "-time-input",
+                        "key": f"{streamlit_kwargs.get('key')}-time-input",
                     }
                     if streamlit_kwargs.get("value"):
                         try:
@@ -693,9 +693,9 @@ class InputUI:
 
         if self._session_state.get(streamlit_kwargs["key"]) is None:
             if property.get("init_value") is not None:
-                streamlit_kwargs["value"] = number_transform(property.get("init_value"))
+                streamlit_kwargs["value"] = number_transform(property["init_value"])
             elif property.get("default") is not None:
-                streamlit_kwargs["value"] = number_transform(property.get("default"))  # type: ignore
+                streamlit_kwargs["value"] = number_transform(property["default"])  # type: ignore
             else:
                 if "min_value" in streamlit_kwargs:
                     streamlit_kwargs["value"] = streamlit_kwargs["min_value"]
@@ -708,7 +708,7 @@ class InputUI:
                     )
         else:
             streamlit_kwargs["value"] = number_transform(
-                self._session_state.get(streamlit_kwargs["key"])
+                self._session_state[streamlit_kwargs["key"]]
             )
 
         if "min_value" in streamlit_kwargs and "max_value" in streamlit_kwargs:
@@ -731,9 +731,7 @@ class InputUI:
             full_key = key + "." + property_key
 
             if property.get("init_value"):
-                new_property["init_value"] = dict(property.get("init_value")).get(
-                    property_key
-                )
+                new_property["init_value"] = property["init_value"].get(property_key)
 
             new_property["readOnly"] = property.get("readOnly", False)
 
@@ -767,12 +765,12 @@ class InputUI:
 
     def _render_list_item(
         self,
-        streamlit_app,
+        streamlit_app: Any,
         parent_key: str,
-        value,
+        value: Any,
         index: int,
         property: Dict[str, Any],
-    ):
+    ) -> Any:
 
         label = "Item #" + str(index + 1)
         new_key = self._key + "-" + parent_key + "." + str(index)
@@ -808,12 +806,12 @@ class InputUI:
 
     def _render_dict_item(
         self,
-        streamlit_app,
+        streamlit_app: Any,
         parent_key: str,
         in_value: Tuple[str, Any],
         index: int,
         property: Dict[str, Any],
-    ):
+    ) -> Any:
 
         new_key = self._key + "-" + parent_key + "." + str(index)
         item_placeholder = streamlit_app.empty()
@@ -901,9 +899,9 @@ class InputUI:
     def _render_list_add_button(
         self,
         key: str,
-        streamlit_app,
-        data_list,
-    ):
+        streamlit_app: Any,
+        data_list: List[Any],
+    ) -> List[Any]:
         if streamlit_app.button(
             "Add Item",
             key=self._key + "-" + key + "list-add-item",
@@ -915,9 +913,9 @@ class InputUI:
     def _render_list_clear_button(
         self,
         key: str,
-        streamlit_app,
-        data_list,
-    ):
+        streamlit_app: Any,
+        data_list: List[Any],
+    ) -> List[Any]:
         if streamlit_app.button(
             "Clear All",
             key=self._key + "_" + key + "-list_clear-all",
@@ -926,7 +924,9 @@ class InputUI:
 
         return data_list
 
-    def _render_dict_add_button(self, key: str, streamlit_app, data_dict):
+    def _render_dict_add_button(
+        self, key: str, streamlit_app: Any, data_dict: Dict[str, Any]
+    ) -> Dict[str, Any]:
         if streamlit_app.button(
             "Add Item",
             key=self._key + "-" + key + "-add-item",
@@ -938,9 +938,9 @@ class InputUI:
     def _render_dict_clear_button(
         self,
         key: str,
-        streamlit_app,
-        data_dict,
-    ):
+        streamlit_app: Any,
+        data_dict: Dict[str, Any],
+    ) -> Dict[str, Any]:
         if streamlit_app.button(
             "Clear All",
             key=self._key + "-" + key + "-clear-all",

--- a/src/streamlit_pydantic/ui_renderer.py
+++ b/src/streamlit_pydantic/ui_renderer.py
@@ -212,9 +212,15 @@ class InputUI:
         if label and self._lowercase_labels:
             label = label.lower()
 
+        disabled = False
+        if property.get("readOnly"):
+            # Read only property -> only show value
+            disabled = True
+
         streamlit_kwargs = {
             "label": label,
             "key": str(self._session_state.run_id) + "-" + str(self._key) + "-" + key,
+            "disabled": disabled
             # "on_change": detect_change, -> not supported for inside forms
             # "args": (key,),
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bugfix
- [ ] New Feature
- [x] Feature Improvement
- [x] Refactoring
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include [WIP] within the title. -->
Hello again 😄

From a user/dev perspective the changes introduced by this PR are:

1. Support the `readOnly` pydantic field property in all pydantic widgets by making use of streamlits `disabled` widget property (fully introduced in streamlit 1.5.0 and pinned to this version in `setup.py`) 
2. Enhance the new list add/remove/clear buttons to respect `max_items` and `min_items` pydantic field properties that might be present in the model.
3. Add support for all existing widget types (eg. date, time, boolean etc..) to be rendered in lists and dicts with full validation and formatting options. This is a result of some refactoring to improve code re-use.  eg. There is now only one function that rendered a number field, regardless of whether that  field is a standalone property or contained within in a list, dict or complex object. 

A new showcase example `complex_disabled_showcase.py` has been added to test/demonstrate all of the major widgets in thier disabled form.
`complex_instance_model.py` has also been updated to demonstrate some of the now supported collection properties and data types.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
