### PR TITLE
Allow an instance of dataclass to be used to initialise sp.pydantic_input

### DIFF
--- a/examples/dataclass_form.py
+++ b/examples/dataclass_form.py
@@ -14,6 +14,22 @@ class ExampleModel:
     some_text: str = "default input"
 
 
-data = sp.pydantic_form(key="my_form", model=ExampleModel)
-if data:
-    st.json(json.dumps(data, default=pydantic_encoder))
+from_model_tab, from_instance_tab = st.tabs(
+    ["Form inputs from model", "Form inputs from instance"]
+)
+
+with from_model_tab:
+    data = sp.pydantic_form(key="my_form", model=ExampleModel)
+    if data:
+        st.json(json.dumps(data, default=pydantic_encoder))
+
+with from_instance_tab:
+    instance = ExampleModel(
+        some_number=999, some_boolean=True, some_text="instance text"
+    )
+
+    # FIXME: this should be a pydantic_form to match the "from model.." above
+    # but initialising a pydantic_form with an instance is not yet supported
+    instance_input_data = sp.pydantic_input(key="my_form_instance", model=instance)
+    if instance:
+        st.json(json.dumps(instance_input_data, default=pydantic_encoder))

--- a/examples/dataclass_form.py
+++ b/examples/dataclass_form.py
@@ -31,5 +31,5 @@ with from_instance_tab:
     # FIXME: this should be a pydantic_form to match the "from model.." above
     # but initialising a pydantic_form with an instance is not yet supported
     instance_input_data = sp.pydantic_input(key="my_form_instance", model=instance)
-    if instance:
+    if instance_input_data:
         st.json(json.dumps(instance_input_data, default=pydantic_encoder))

--- a/src/streamlit_pydantic/ui_renderer.py
+++ b/src/streamlit_pydantic/ui_renderer.py
@@ -100,7 +100,14 @@ class InputUI:
             # Convert dataclasses
             import pydantic
 
-            self._input_class = pydantic.dataclasses.dataclass(model).__pydantic_model__  # type: ignore
+            if isinstance(model, type):
+                self._input_class = pydantic.dataclasses.dataclass(model).__pydantic_model__  # type: ignore
+            else:
+                # When model is a dataclass instance, do a full conversion to a BaseModel instance
+                self._input_class = pydantic.dataclasses.dataclass(
+                    model.__class__  # type: ignore
+                ).__pydantic_model__(**model.__dict__)
+
         else:
             self._input_class = model
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bugfix
- [ ] New Feature
- [x] Feature Improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include [WIP] within the title. -->
A small fix to allow a dataclass instance to be used to initialise a sp.pydantic_input.

The dataclass form playground example has been updated to demonstrate/test the usage.  

Note the FIXME in dataclass_form.py. Instance support for sp.pydantic_form would be better delivered in a separate PR.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
