### PR TITLE
Add the ability to pass in an instance to sp.pydantic_form()

### DIFF
--- a/examples/simple_form.py
+++ b/examples/simple_form.py
@@ -10,6 +10,20 @@ class ExampleModel(BaseModel):
     some_boolean: bool
 
 
-data = sp.pydantic_form(key="my_form", model=ExampleModel)
-if data:
-    st.json(data.json())
+from_model_tab, from_instance_tab = st.tabs(
+    ["Form inputs from model", "Form inputs from instance"]
+)
+
+with from_model_tab:
+    data = sp.pydantic_form(key="my_form", model=ExampleModel)
+    if data:
+        st.json(data.json())
+
+with from_instance_tab:
+    instance = ExampleModel(
+        some_number=999, some_boolean=True, some_text="instance text"
+    )
+
+    instance_input_data = sp.pydantic_form(key="my_form_instance", model=instance)
+    if instance_input_data:
+        st.json(instance_input_data.json())

--- a/src/streamlit_pydantic/ui_renderer.py
+++ b/src/streamlit_pydantic/ui_renderer.py
@@ -1313,7 +1313,11 @@ def pydantic_form(
 
         if submit_button:
             try:
-                return parse_obj_as(model, input_state)
+                # check if the model is an instance before parsing
+                if isinstance(model, BaseModel):
+                    return parse_obj_as(model.__class__, input_state)
+                else:
+                    return parse_obj_as(model, input_state)
             except ValidationError as ex:
                 error_text = "**Whoops! There were some problems with your input:**"
                 for error in ex.errors():


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bugfix
- [ ] New Feature
- [x] Feature Improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include [WIP] within the title. -->
With #16 and #17 it has been made possible to initialise a streamlit form using a `BaseModel` instance and have the instances field  values pre-populated in all the relevant streamlit form fields.

Currently this feature is supported only when using `sp.pydantic_input()` and not `sp.pydantic_form()`.

This PR adds instance support to `sp.pydantic_form()` to bring it into line with the features of `sp.pydantic_input()`

The `simple_form.py` showcase example has been extended to demonstrate/test the new functionality.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
