### PR TITLE
Support default values for dicts, lists and embedded objects

### DIFF
--- a/examples/complex_defaults.py
+++ b/examples/complex_defaults.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Set
 
 import streamlit as st
 from pydantic import BaseModel, Field
+from pydantic.color import Color
 
 import streamlit_pydantic as sp
 
@@ -43,6 +44,7 @@ class ExampleModel(BaseModel):
         description="This is ready only text.",
         readOnly=True,
     )
+    default_color: Color = Field("yellow", description="A defaulted color")
     default_object: OtherData = Field(
         OtherData(),
         description="An object embedded into the model with a default",

--- a/src/streamlit_pydantic/ui_renderer.py
+++ b/src/streamlit_pydantic/ui_renderer.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar
 import pandas as pd
 import streamlit as st
 from pydantic import BaseModel, ValidationError, parse_obj_as
+from pydantic.color import Color
 from pydantic.json import pydantic_encoder
 
 from streamlit_pydantic import schema_utils
@@ -439,6 +440,11 @@ class InputUI:
             streamlit_kwargs["value"] = property["default"]
         elif property.get("example") is not None:
             streamlit_kwargs["value"] = property["example"]
+
+        if isinstance(streamlit_kwargs.get("value"), Color):
+            streamlit_kwargs["value"] = streamlit_kwargs["value"].as_hex()
+        elif isinstance(streamlit_kwargs.get("value"), str):
+            streamlit_kwargs["value"] = Color(streamlit_kwargs["value"]).as_hex()
 
         if property.get("format") == "text":
             # Use text input if specified format is text


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] New Feature
- [ ] Feature Improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include [WIP] within the title. -->

Issue #26 has highlighted a minor issue where `pydantic` `Field`'s of type: `dict`, `list` and  `object` are not being checked or respected when these types of fields are rendered by `streamlit`.

Color widgets also sometimes fail to render properly when initialised from `default` and instance values due to the variety of different ways that `pydantic` `Color`'s can be defined.

This PR addresses these issues and adds a new showcase/demo page to demonstrate the functionality.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
