### PR TITLE
fix instance bool render bug

### DIFF
--- a/src/streamlit_pydantic/ui_renderer.py
+++ b/src/streamlit_pydantic/ui_renderer.py
@@ -668,9 +668,9 @@ class InputUI:
         streamlit_kwargs = self._get_default_streamlit_input_kwargs(key, property)
         overwrite_kwargs = self._get_overwrite_streamlit_kwargs(key, property)
 
-        if property.get("init_value"):
+        if "init_value" in property:
             streamlit_kwargs["value"] = property.get("init_value")
-        elif property.get("default"):
+        elif "default" in property:
             streamlit_kwargs["value"] = property.get("default")
 
         # special formatting when rendering within a list/dict


### PR DESCRIPTION
---- test:

from pydantic import BaseModel

import streamlit_pydantic as sp

class ExampleModel(BaseModel):
    some_text: str
    some_number: int = 10
    is_xx: bool = True

instance = ExampleModel(some_text="abc123", some_number=23324, is_xx=False)

ret = sp.pydantic_input(key="aaa", model=instance)

**What kind of change does this PR introduce?**

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] New Feature
- [ ] Feature Improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include [WIP] within the title. -->

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
