### PR TITLE
Fix ImportError with pydantic 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_dir={"": "src"},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     zip_safe=False,
-    install_requires=["streamlit>=1.14.0", "pydantic>=1.9", "importlib-resources"],
+    install_requires=["streamlit>=1.14.0", "pydantic>=2.0", "pydantic-settings>=2.0", "importlib-resources"],
     # deprecated: dependency_links=dependency_links,
     extras_require={
         # extras can be installed via: pip install package[dev]

--- a/src/streamlit_pydantic/_about.py
+++ b/src/streamlit_pydantic/_about.py
@@ -1,5 +1,5 @@
 """Information about this library. This file will automatically changed."""
 
-__version__ = "0.6.0.dev1"
+__version__ = "0.7.0"
 # __author__
 # __email__

--- a/src/streamlit_pydantic/settings.py
+++ b/src/streamlit_pydantic/settings.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 import streamlit as st
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 def _streamlit_secrets_source(settings: BaseSettings) -> Dict[str, Any]:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] New Feature
- [ ] Feature Improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

Makes `streamlit-pydantic` compatible with `pydantic~=2.0`.

**Checklist:**


- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
