### PR TITLE
Typo "date" validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ if data:
     st.json(data.model_dump())
 ```
 
-### Date Validation
+### Data Validation
 
 ```python
 import streamlit as st


### PR DESCRIPTION
Fix typo in readme

## Describe your changes
The readme says "date validation" but appears to mean data validation.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the MIT license.
