### PR TITLE
Add the ability to put items in an expander by annotating Pydantic model fields

### DIFF
--- a/examples/expanders.py
+++ b/examples/expanders.py
@@ -1,0 +1,30 @@
+"""
+An example of using the Expander annotation with nested objects.
+"""
+
+from typing_extensions import Annotated, List
+from pydantic import BaseModel
+import streamlit as st
+import streamlit_pydantic as sp
+from streamlit_pydantic import Expander
+
+
+class Child(BaseModel):
+    """Child class."""
+
+    name: str
+    age: int
+
+
+class Parent(BaseModel):
+    """Parent class."""
+
+    occupation: str
+    child: Annotated[List[Child], Expander]
+
+
+data = sp.pydantic_input("form", model=Parent)
+
+if data:
+    obj = Parent.model_validate(data)
+    st.json(obj.model_dump())

--- a/src/streamlit_pydantic/__init__.py
+++ b/src/streamlit_pydantic/__init__.py
@@ -16,3 +16,5 @@ pydantic_input = st._gather_metrics("pydantic_input", _pydantic_input)
 from .ui_renderer import pydantic_output as _pydantic_output
 
 pydantic_output = st._gather_metrics("pydantic_output", _pydantic_output)
+
+from .annotations import Expander

--- a/src/streamlit_pydantic/annotations.py
+++ b/src/streamlit_pydantic/annotations.py
@@ -1,0 +1,8 @@
+"""
+Annotations to be used within Pydantic objects.
+"""
+
+from typing import Annotated, TypeVar
+
+
+Expander = TypeVar("Expander")


### PR DESCRIPTION
## This pull request adds the ability to put items in an expander by annotating fields of a Pydantic model with an Expander annotation.  An example of this is also added to the examples directory.

## Addresses #24 but may not fully close it.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the MIT license.
